### PR TITLE
update -fix migrate error 解決- 

### DIFF
--- a/db/migrate/20190922113149_add_column_products.rb
+++ b/db/migrate/20190922113149_add_column_products.rb
@@ -2,6 +2,6 @@ class AddColumnProducts < ActiveRecord::Migration[5.2]
   def change
     add_column :products, :child_category,:integer
 
-    add_column :products, :grandchild_category,:integert
+    add_column :products, :grandchild_category,:integer
   end
 end


### PR DESCRIPTION
ファイル「20190922113149_add_column_products.rb」

add_column :products, :grandchild_category,:integert
↓
add_column :products, :grandchild_category,:integer
綴りミスがありましたので、修正しました。